### PR TITLE
docs: make shared FCM partial platform-neutral (not Unity-specific)

### DIFF
--- a/modules/integrations/pages/firebase-fcm.adoc
+++ b/modules/integrations/pages/firebase-fcm.adoc
@@ -17,7 +17,7 @@ In this guide, we'll download a Service Account Key (in JSON format), and copy t
 +
 [IMPORTANT]
 ====
-If you need to confirm that you have the correct Firebase project: Open the `google-services.json` file from your Unity Project and find the `project_number`. Confirm that the value matches the `Sender ID` value on the menu:Cloud Messaging[] tab.
+If you need to confirm that you have the correct Firebase project: Open the `google-services.json` file from your project and find the `project_number`. Confirm that the value matches the `Sender ID` value on the menu:Cloud Messaging[] tab.
 ====
 
 . Click the **gear icon** in the upper left corner, and click **Project settings**.


### PR DESCRIPTION
The `integrations/firebase-fcm.adoc` partial is shared by the **Unity** and **Android** SDK quickstarts. One line told readers to open `google-services.json` "from your **Unity Project**", which now renders on the Android quickstart (added in GoCarrot/teak-android#157) — where a native-Android developer has no Unity project.

Changed "from your Unity Project" → "from your project" so it reads correctly for both consumers. No behavior or structure change.

## Verification

`npx antora` exits 0 with no new warnings. Confirmed both the Android and Unity built `quickstart/firebase-fcm.html` pages now read "from your project", and no "Unity Project" text remains in the Android output.

🤖 Generated with [Claude Code](https://claude.ai/code)