### PR TITLE
Add a Shortcuts bar to the top of the Developer Quickstart

### DIFF
--- a/modules/ROOT/pages/developer-quickstart.adoc
+++ b/modules/ROOT/pages/developer-quickstart.adoc
@@ -4,6 +4,61 @@
 
 Teak brings players back to free-to-play games with rewardable push notifications, emails, and links. You integrate it with a platform SDK on the client, and connect your backend to the Teak Server API. This page walks through what an integration involves and points you to the right guide for your platform.
 
+// Quicklinks bar (added by Claude): compact icon links to each platform guide,
+// so the routing is visible above the fold without scrolling down to "Choose
+// Your SDK". Reuses the nav-table/iconblock pattern with a `quicklinks` role
+// for the compact styling in antora-ui-teak doc.css.
+== Shortcuts
+
+[cols="5", role="nav-table quicklinks", frame="none", grid="none"]
+|===
+a|
+
+[.iconblock]
+====
+image::unity.svg[Unity,28,xref=unity::page$quickstart/index.adoc]
+
+xref:unity::page$quickstart/index.adoc[*Unity*]
+====
+
+a|
+
+[.iconblock]
+====
+image::javascript.svg[JavaScript,28,xref=javascript::page$quickstart/index.adoc]
+
+xref:javascript::page$quickstart/index.adoc[*JavaScript*]
+====
+
+a|
+
+[.iconblock]
+====
+image::appstore.svg[iOS,28,xref=ios::page$integration.adoc]
+
+xref:ios::page$integration.adoc[*iOS*]
+====
+
+a|
+
+[.iconblock]
+====
+image::android.svg[Android,28,xref=android::page$integration.adoc]
+
+xref:android::page$integration.adoc[*Android*]
+====
+
+a|
+
+[.iconblock]
+====
+image::terminal.svg[Server API,28,xref=server-api::page$index.adoc]
+
+xref:server-api::page$index.adoc[*Server API*]
+====
+
+|===
+
 == How a Teak Integration Works
 
 Every Teak integration is the same six steps. Steps 1 through 5 run on the client, and your platform's quickstart walks you through each one. Step 6 connects your backend to Teak:


### PR DESCRIPTION
Part of GoCarrot/antora-ui-teak#29. Content half; styling is in GoCarrot/antora-ui-teak#30.

## Why

The page's main platform routing ("Choose Your SDK") sits below the fold, so a developer who just wants their docs has to scroll. This adds a **Shortcuts** section right under the intro: a compact row of five icon links straight to each platform's guide.

## What

A new `== Shortcuts` section with a five-cell `nav-table` (role `quicklinks`):

| Label | Links to |
|-------|----------|
| Unity | Unity SDK quickstart |
| JavaScript | JavaScript SDK quickstart |
| iOS | iOS native SDK integration guide |
| Android | Android native SDK integration guide |
| Server API | Server API reference |

Reuses the existing `nav-table`/`iconblock` pattern; icons sized to 28px. The compact even-width styling for the `quicklinks` role is in **GoCarrot/antora-ui-teak#30** — this PR needs that one to render correctly.

## Verification

Built locally and rendered the real page in Chrome and Firefox (desktop + 560px); five even-width cards, correct links. A staging preview from the paired UI branch built successfully (CircleCI #1092).

🤖 Generated with [Claude Code](https://claude.ai/code)