### PR TITLE
Include android nav in unified Developer Guides nav

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -89,6 +89,7 @@
 include::unity::partial$nav-unity.adoc[]
 include::javascript::partial$nav-javascript.adoc[]
 include::ios::partial$nav-ios.adoc[]
+include::android::partial$nav-android.adoc[]
 include::server-api::partial$nav-server-api.adoc[]
 
 * SDK & API Reference

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,15 +1,5 @@
 * xref:index.adoc[Overview]
 
-// * Working with Teak
-// ** Feature Overview
-// ** Intro to Games CRM
-// ** Lifecycle Strategies
-// ** Daily Mystery Bonus
-// ** Helpful Audiences
-// ** Creating Effective Campaigns
-// ** Managing Rewards
-// ** Analyzing Player Data
-
 * xref:ROOT:user-guide:page$index.adoc[[.default-open]#User Guide#]
 ** xref:user-guide:page$glossary.adoc[Glossary]
 ** xref:user-guide:page$reporting.adoc[Reporting]
@@ -32,58 +22,6 @@
 ** xref:user-guide:page$scheduling.adoc[Scheduling]
 *** xref:user-guide:page$varied-recurring-messages.adoc[Varying Content in a Single Schedule]
 ** xref:user-guide:page$settings.adoc[Settings]
-
-// * User Guide
-// ** Quickstart
-// ** xref:user-guide:page$audiences.adoc[Audiences]
-// *** xref:user-guide:page$audiences.adoc[Overview]
-// *** xref:user-guide:page$helpful-audiences.adoc[Helpful Audiences]
-// ** xref:user-guide:page$scheduling.adoc[Schedules]
-// ** xref:user-guide:page$notifications.adoc[Push Notifications]
-// *** xref:user-guide:page$notifications.adoc[Overview]
-// *** Local Notifications
-// *** Content Guidelines
-// *** xref:user-guide:page$notification-markup.adoc[Text Markup]
-// ** Web Push
-// *** Overview
-// *** Local Notifications
-// *** iOS Content Guidelines
-// *** Text Markup
-// ** xref:user-guide:page$email.adoc[Email]
-// *** Overview
-// *** Templating
-// *** Text Markup
-// ** xref:user-guide:page$links.adoc[Universal Links]
-// *** Overview
-// *** Rewarded Links
-// *** Link Metrics
-// *** QR Codes
-// ** xref:user-guide:page$rewards.adoc[Rewards]
-// *** Overview
-// *** Tiered Rewards
-// *** Randomized Rewards
-// ** xref:user-guide:page$custom-tags.adoc[Custom Tags]
-// ** A/B Testing
-// *** Push Content
-// *** Email Content
-// ** xref:user-guide:page$reporting.adoc[Reporting]
-// *** Dashboard Metrics
-// *** Data Sync
-// ** xref:user-guide:page$settings.adoc[Settings]
-// ** xref:user-guide:page$glossary.adoc[Glossary]
-// ** xref:user-guide:page$faq.adoc[Dashboard FAQ]
-
-// * [.default-open]#Developer Guides#
-// ** Integration Overview
-// include::unity::partial$nav-unity.adoc[]
-// include::ios::partial$nav-ios.adoc[]
-// include::android::partial$nav-android.adoc[]
-// ** Javascript SDK
-// *** Getting Started with Javascript
-// *** Features
-// *** Advanced Setup
-// *** SDK5 Preview
-// *** Changelog
 
 * xref::page$developer-quickstart.adoc[[.default-open]#Developer Guides#]
 include::unity::partial$nav-unity.adoc[]


### PR DESCRIPTION
Closes #c-934

## Summary
- Adds `include::android::partial$nav-android.adoc[]` to the live Developer Guides block in `modules/ROOT/nav.adoc`, alongside unity/js/ios/server-api, so the Android SDK guide renders in unified nav.
- Placed after ios per antora-ui-teak's `page-sdk-nav-sort-order` (unity, ios, android, server-api).

## Verification
- `nav-android.adoc` partial exists, module name (`android`) matches the include, and all 7 xref'd pages exist in the android SDK source.
- CI Antora build: SUCCESS — confirms the android guide renders clean in unified nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)